### PR TITLE
feature: LuaDocs

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -17,4 +17,4 @@ help:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -b $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/source/builders/luadoc.py
+++ b/docs/source/builders/luadoc.py
@@ -1,0 +1,116 @@
+import json
+from sphinx.builders import Builder
+from docutils import nodes
+from luastruct import *
+import os
+
+class LuaJSONBuilder(Builder):
+    name = 'luadoc'
+    epilog = 'Building custom JSON output.'
+
+    def init(self):
+        self.docnames = []
+        self.documents = {}
+
+    def get_outdated_docs(self):
+        return self.env.found_docs
+
+    def get_target_uri(self, docname, typ=None):
+        return f"{docname}.json"
+
+    def prepare_writing(self, docnames):
+        self.docnames.extend(docnames)
+
+    def write_doc(self, docname, doctree):
+        self.documents[docname] = self.env.get_doctree(docname)
+
+    def finish(self):
+        output = {}
+        for docname, doctree in self.documents.items():
+            visitor = LuaJSONVisitor(self, doctree)
+            doctree.walkabout(visitor)
+            output[docname] = visitor.get_data()
+
+        with open(os.path.join(self.outdir, 'output.json'), 'w') as f:
+            json.dump(output, f, indent=2)
+
+class LuaJSONVisitor(nodes.NodeVisitor):
+    def __init__(self, builder, doc):
+        super().__init__(doc)
+        self.builder = builder
+        self.data = []
+        self.stack = []
+
+    def visit_target(self, node):
+        pass #print(f"Target: visiting node: {node}")
+
+    def visit_section(self, node):
+        if node.attributes.get('domain') == 'lua' and node.attributes.get('objtype') in ['class', 'staticmethod', 'attribute']:
+            if node.attributes['objtype'] == 'class':
+                lua_class = LuaClass(node.children[0].astext().split()[-1])
+                self.stack.append(lua_class)
+                print("Found class")
+            elif node.attributes['objtype'] == 'staticmethod':
+                method = LuaMethod(node.children[0].astext().split()[-1])
+                self.stack[-1].methods.append(method)
+                self.stack.append(method)
+                print("Found static method")
+            elif node.attributes['objtype'] == 'attribute':
+                attr_name = node.children[0].astext().split()[-1]
+                attr_type = node.children[0].next_sibling.astext() if node.children[0].next_sibling else 'unknown'
+                attribute = LuaAttribute(attr_name, attr_type)
+                self.stack[-1].attributes.append(attribute)
+                self.stack.append(attribute)
+                print("Found attribute")
+        self.generic_visit(node)
+
+    def visit_paragraph(self, node):
+        pass #print(f"Paragraph: visiting node: {node}")
+
+    def visit_text(self, node):
+        pass #print(f"Text: visiting node: {node}")        
+
+    def visit_title(self, node):
+        pass #print(f"Text: visiting node: {node}")                
+
+    def unknown_visit(self, node):   
+        if hasattr(node, 'attributes'):
+            match node.attributes.get('objtype'):
+                case 'attribute':
+                    attribute = LuaAttribute(node)
+                    print(f"⭐️ {attribute}")
+                    # for child in node.children:
+                    #     print("\n")
+                    #     print(vars(child))
+                    #     print("\n")
+
+                case 'staticmethod':
+                    staticmethod = LuaStaticMethod(node)
+                    print(f"⭐️ {staticmethod}")
+                    for child in node.children:
+                        print("\n")
+                        print(child)
+                        print("\n")
+
+    def unknown_departure(self, node):        
+        pass #print(f"Departing unknown node type: {type(node).__name__}")
+
+    def generic_visit(self, node):
+        if node.attributes.get('domain') == 'lua' and node.attributes.get('objtype'):
+            print(f"Generic node: {node.attributes['objtype']}")
+
+    def get_data(self):
+        return self.data
+
+def setup(app):
+    app.add_builder(LuaJSONBuilder)
+
+
+import inspect
+
+def get_attributes(obj):
+    # Fetch all members of the object that are not callable (hence not methods)
+    # and also not any of the built-in Python attributes (typically named with double underscores).
+    attributes = inspect.getmembers(obj, lambda a: not(inspect.isroutine(a)))
+    return [a for a in attributes if not (a[0].startswith('__') and a[0].endswith('__'))]
+

--- a/docs/source/builders/luastruct.py
+++ b/docs/source/builders/luastruct.py
@@ -1,0 +1,210 @@
+from docutils import nodes
+
+class LuaClass:
+    def __init__(self, name):
+        self.name = name
+        self.description = ''
+        self.methods = []
+        self.attributes = []
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'description': self.description,
+            'methods': [method.to_dict() for method in self.methods],
+            'attributes': [attr.to_dict() for attr in self.attributes]
+        }
+
+class LuaMethod:
+    def __init__(self, name):
+        self.name = name
+        self.parameters = []
+        self.return_description = ''
+        self.return_type = ''
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'parameters': self.parameters,
+            'return_description': self.return_description,
+            'return_type': self.return_type
+        }
+    
+    
+class LuaParameter:
+    def __init__(self, name, type_hint=None, optional=False, description=None, default=None):
+        self.name = name
+        self.type_hint = type_hint
+        self.optional = optional
+        self.description = description
+        self.default = default
+
+    def __str__(self):
+        default_str = f" [Default: {self.default}]" if self.default is not None else ""
+        optional_str = "Optional" if self.optional else "Required"
+        return f"Parameter(Name: {self.name}, Type: {self.type_hint}, {optional_str}{default_str}, Description: {self.description})"
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'type_hint': self.type_hint,
+            'optional': self.optional,
+            'description': self.description,
+            'default': self.default
+        }
+
+    
+
+class LuaReturn:
+    def __init__(self, type_hint=None, description=None):
+        self.type_hint = type_hint
+        self.description = description
+
+    def __str__(self):
+        return f"Return(Type: {self.type_hint}, Description: {self.description})"
+
+    def to_dict(self):
+        return {
+            'type_hint': self.type_hint,
+            'description': self.description
+        }
+
+
+class LuaStaticMethod:
+    def __init__(self, node):
+        self.name = self.extract_name(node)
+        self.description = self.extract_description(node)
+        self.parameters = self.extract_parameters(node)
+        self.returns = self.extract_returns(node)
+
+    def extract_name(self, node):
+        name_node = next((child for child in node.traverse() if child.tagname == 'desc_name'), None)
+        return name_node.astext() if name_node else None
+
+    def extract_description(self, node):
+        content_node = next((child for child in node.traverse() if child.tagname == 'desc_content'), None)
+        return content_node.astext() if content_node else None
+
+    def extract_parameters(self, node):
+        params = []
+        param_list = node.next_node(condition=lambda n: n.tagname == 'desc_parameterlist')
+        # Search for the field list that contains parameter details
+        field_list = node.next_node(condition=lambda n: n.tagname == 'field_list')
+        param_details = {}
+        if field_list:
+            for field in field_list.children:
+                if isinstance(field, nodes.field):
+                    param_name_node = field.next_node(condition=lambda n: n.tagname == 'literal_strong')
+                    param_description_nodes = field.next_node(condition=lambda n: n.tagname == 'paragraph')
+                    if param_name_node and param_description_nodes:
+                        param_name = param_name_node.astext().split('=')[0].strip()  # Handle default values here if specified
+                        default_value = param_name_node.astext().split('=')[1].strip() if '=' in param_name_node.astext() else None
+                        # Extract the type if available within parenthesis
+                        param_type = None
+                        description_text = param_description_nodes.astext()
+                        if '(' in description_text and ')' in description_text:
+                            start = description_text.find('(') + 1
+                            end = description_text.find(')')
+                            param_type = description_text[start:end]
+                        # Description often follows the type enclosed in dash
+                        param_description = description_text.split('–')[-1].strip()
+                        param_details[param_name] = {
+                            'type': param_type,
+                            'description': param_description,
+                            'default': default_value
+                        }
+
+        if param_list:
+            for child in param_list.children:
+                if child.tagname == 'desc_parameter' or child.tagname == 'desc_optional':
+                    for param_node in child.children:
+                        param_name = param_node.astext().split('=')[0].strip()
+                        default_value = param_node.astext().split('=')[1].strip() if '=' in param_node.astext() else None
+                        optional = child.tagname == 'desc_optional'
+                        param_info = param_details.get(param_name, {})
+                        params.append(LuaParameter(name=param_name,
+                                                   type_hint=param_info.get('type'),
+                                                   optional=optional,
+                                                   description=param_info.get('description'),
+                                                   default=default_value or param_info.get('default')))
+
+        return params
+
+    def extract_returns(self, node):
+        returns = []
+        return_nodes = node.next_node(condition=lambda n: n.tagname == 'field_list')
+        if return_nodes:
+            for field in return_nodes.children:
+                if isinstance(field, nodes.field) and 'Returns' in field.children[0].astext():
+                    return_desc = field.children[1].astext()
+                    returns.append(LuaReturn(description=return_desc))
+                elif isinstance(field, nodes.field) and 'Return type' in field.children[0].astext():
+                    # We assume there's an <inline> tag wrapping the type description
+                    for para in field.traverse(nodes.paragraph):
+                        type_text = ''.join([n.astext() for n in para.traverse() if isinstance(n, nodes.Text)])
+                        if returns:
+                            returns[0].type_hint = type_text  # Assuming only one return entry is common
+                        else:
+                            # In case the return type is specified before the description
+                            returns.append(LuaReturn(type_hint=type_text))
+        return returns
+
+    def __str__(self):
+        parameter_str = "\n\t".join(str(param) for param in self.parameters)
+        returns_str = "\n\t".join(str(return_val) for return_val in self.returns)
+        return f"{self.name}\n\tDescription: {self.description}\n\tParameters:\n\t{parameter_str}\n\tReturns:\n\t{returns_str}"
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'description': self.description,
+            'parameters': [p.to_dict() for p in self.parameters],
+            'returns': [r.to_dict() for r in self.returns]
+        }
+
+
+class LuaAttribute:
+    def __init__(self, node):
+        self.name = self.extract_name(node)
+        self.default_value = None  # Initializing default value
+        self.type = self.extract_type(node)
+        self.description = self.extract_description(node)        
+
+    def extract_name(self, node):
+        # Finds the first 'desc_name' element and extracts its text.
+        name_node = next((child for child in node.traverse() if child.tagname == 'desc_name'), None)
+        return name_node.astext() if name_node else None
+
+    def extract_type(self, node):
+        # Finds the first 'desc_type' element and extracts its text, along with any default value if specified.
+        type_node = next((child for child in node.traverse() if child.tagname == 'desc_type'), None)
+        if type_node:
+            type_text = type_node.astext()
+            # Check for default value pattern in the type text
+            if '[' in type_text and 'default' in type_text:
+                # Extract the type up to the '['
+                type_name = type_text[:type_text.find('[')].strip()
+                # Extract default value after 'default ='
+                default_start = type_text.find('default =') + len('default =')
+                default_end = type_text.find(']', default_start)
+                self.default_value = type_text[default_start:default_end].strip()
+                return type_name
+            return type_text
+        return None
+
+    def extract_description(self, node):
+        # Finds the first paragraph in 'desc_content' and extracts its text.
+        content_node = next((child for child in node.traverse() if child.tagname == 'desc_content'), None)
+        return content_node.astext() if content_node else None
+
+    def __str__(self):
+        return f"{self.name}: {self.type} [Default: {self.default_value}]\n\t{self.description}"
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'type': self.type,
+            'default_value': self.default_value,
+            'description': self.description
+        }
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,10 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+import os
+import sys
+sys.path.insert(0, os.path.abspath('./builders'))
 
 # -- Project information -----------------------------------------------------
 
@@ -31,6 +30,7 @@ release = '4.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'luadoc',
     'sphinxcontrib.luadomain',
     'sphinx_copybutton',
     'sphinx_toolbox.collapse'
@@ -65,3 +65,4 @@ html_favicon = 'images/favicon.ico'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+


### PR DESCRIPTION
A luadoc builder for Sphinx which attempts to parse the lua-annotated rst docs into a structured format. We'll have to make some rules around how certain things are written. For now these are captured:

### Attributes with default values

For an attribute, default values are parsed by looking for `[default = value]` after the presence of the type (`number` in this case)

```
.. lua:attribute:: polygonOffsetConstant: number [default = 0.5]
                  
   This represents the constant factor used in polygon offset calculations. It adjusts the depth values of rendered polygons to resolve depth fighting issues. The default value is set to 0.5
```

### Parameters with default values

`parameter = value` in the optional parameter list indicates the default value to be assigned for that parameter if not specified

```
.. lua:staticmethod:: play3d(source[, volume = 1, pitch = 1, paused = false])   

   Plays a ``sound.source`` in 3D, returning an active ``sound.instance`` object that can be adjusted, paused/resumed and stopped

   :rtype: sound.instance
```

### Note

This PR is unfinished, just opening it so we can discuss it and look at the code together