### PR TITLE
Add drawing manual page and Carbide gotchas documentation

### DIFF
--- a/docs/source/api/matrix.rst
+++ b/docs/source/api/matrix.rst
@@ -103,6 +103,20 @@ Transform
 Projection
 ##########
 
+.. note::
+
+   Codea 4.x uses a **left-handed, +Z-forward** coordinate system for 3D rendering. When :lua:func:`matrix.perspective` is active, the camera is at the origin looking toward **+Z**. Objects must be translated to positive Z to appear in front of the camera. This is the opposite of the -Z-forward convention used in OpenGL and Codea 3.x Craft.
+
+   .. code-block:: lua
+
+      -- Minimal 3D draw loop
+      matrix.push()
+          matrix.perspective(60)          -- 60° FOV, camera at origin, +Z forward
+          matrix.translate(0, 0, 4)       -- object 4 units in front
+          matrix.rotate(angle, 0, 1, 0)
+          myMesh:draw()
+      matrix.pop()
+
 .. lua:function:: ortho()
 
    Set the projection matrix to ortho using the device screen settings (i.e. coordinates range ``[0, 0]`` to ``[WIDTH, HEIGHT]``)

--- a/docs/source/api/mesh.rst
+++ b/docs/source/api/mesh.rst
@@ -171,7 +171,7 @@ mesh
 
    .. lua:attribute:: vertices: table<vec2|vec3>
 
-      Gets/sets the positions of the mesh vertices while also ensuring that each set of three indices match their corresponding vertices. This is the preferred way to assign geometry for manually-built meshes because it automatically creates sequential indices (0, 1, 2, …), making the mesh immediately drawable.
+      Gets/sets the positions of the mesh vertices while also ensuring that each set of three indices match their corresponding vertices. This is the preferred way to assign geometry for manually-built meshes because it automatically populates a sequential index buffer matching the vertex order, making the mesh immediately drawable.
 
       *3.x compatiblity note: works the same as the original vertices property*
 

--- a/docs/source/api/mesh.rst
+++ b/docs/source/api/mesh.rst
@@ -135,7 +135,13 @@ mesh
 
    .. lua:attribute:: positions: table<vec3>
 
-      Gets/sets the positions of the mesh vertices
+      Gets/sets the positions of the mesh vertices **without touching the index buffer**.
+
+      This is the correct property to use when modifying vertex positions on an already-built mesh (e.g. one created by :lua:func:`mesh.sphere`, :lua:func:`mesh.box`, or loaded via :lua:meth:`mesh.read`), since those meshes have optimised index buffers with shared vertices that you want to preserve.
+
+      .. warning::
+
+         When building a mesh **from scratch**, use :lua:attr:`mesh.vertices` instead. Setting ``positions`` alone leaves the index buffer empty, so nothing will be drawn.
 
       .. helptext:: get or set the vertex positions
 
@@ -165,7 +171,7 @@ mesh
 
    .. lua:attribute:: vertices: table<vec2|vec3>
 
-      Gets/sets the positions of the mesh vertices while also ensuring that each set of three indices match their corresponding vertices
+      Gets/sets the positions of the mesh vertices while also ensuring that each set of three indices match their corresponding vertices. This is the preferred way to assign geometry for manually-built meshes because it automatically creates sequential indices (0, 1, 2, …), making the mesh immediately drawable.
 
       *3.x compatiblity note: works the same as the original vertices property*
 

--- a/docs/source/builders/luastruct.py
+++ b/docs/source/builders/luastruct.py
@@ -127,14 +127,33 @@ class DocutilsUtils:
     @staticmethod
     def extract_code_samples(node):
         code_samples = []
+        seen_code = set()
+
+        # Captioned code blocks (.. code-block:: with :caption:) are wrapped in a container
         for container in node.traverse(condition=lambda n: n.tagname == 'container' and 'literal-block-wrapper' in n['classes']):
             caption_node = container.next_node(condition=lambda n: n.tagname == 'caption')
             code_node = container.next_node(condition=lambda n: n.tagname == 'literal_block')
             if caption_node and code_node:
+                code = code_node.astext()
+                seen_code.add(code)
                 code_samples.append({
                     'title': caption_node.astext(),
-                    'code': code_node.astext()
+                    'code': code
                 })
+
+        # Uncaptioned code blocks (plain .. code-block:: lua) appear as bare literal_block nodes
+        desc_content = next((child for child in node.children if child.tagname == 'desc_content'), None)
+        if desc_content:
+            for child in desc_content.children:
+                if child.tagname == 'literal_block':
+                    code = child.astext()
+                    if code not in seen_code:
+                        seen_code.add(code)
+                        code_samples.append({
+                            'title': '',
+                            'code': code
+                        })
+
         return code_samples
     
     @staticmethod

--- a/docs/source/code/RGB Cube.codea/Main.lua
+++ b/docs/source/code/RGB Cube.codea/Main.lua
@@ -1,0 +1,65 @@
+-- RGB Cube
+-- A rotating cube with RGB vertex colors
+
+function setup()
+    viewer.mode = FULLSCREEN
+
+    -- Build a cube mesh with 8 corners
+    cubeMesh = mesh()
+    local s = 0.5
+
+    local v = {
+        vec3(-s,-s,-s), vec3( s,-s,-s), vec3( s, s,-s), vec3(-s, s,-s),
+        vec3(-s,-s, s), vec3( s,-s, s), vec3( s, s, s), vec3(-s, s, s),
+    }
+
+    -- Map each corner's position to an RGB color
+    local function posToColor(p)
+        return color(
+            math.floor((p.x + s) / (2*s) * 255),
+            math.floor((p.y + s) / (2*s) * 255),
+            math.floor((p.z + s) / (2*s) * 255))
+    end
+
+    -- 6 faces × 2 triangles, wound for correct front-face culling
+    local faces = {
+        {v[5],v[6],v[7]}, {v[5],v[7],v[8]}, -- Front  (+z)
+        {v[2],v[1],v[4]}, {v[2],v[4],v[3]}, -- Back   (-z)
+        {v[1],v[5],v[8]}, {v[1],v[8],v[4]}, -- Left   (-x)
+        {v[6],v[2],v[3]}, {v[6],v[3],v[7]}, -- Right  (+x)
+        {v[8],v[7],v[3]}, {v[8],v[3],v[4]}, -- Top    (+y)
+        {v[1],v[2],v[6]}, {v[1],v[6],v[5]}, -- Bottom (-y)
+    }
+
+    local verts, cols = {}, {}
+    for _, tri in ipairs(faces) do
+        for _, p in ipairs(tri) do
+            table.insert(verts, p)
+            table.insert(cols, posToColor(p))
+        end
+    end
+
+    -- Use 'vertices' (not 'positions') so indices are set automatically
+    cubeMesh.vertices = verts
+    cubeMesh.colors   = cols
+
+    angleX, angleY = 0, 0
+end
+
+function draw()
+    background(20, 20, 30)
+
+    angleX = angleX + 0.4
+    angleY = angleY + 0.6
+
+    -- Set up perspective projection.
+    -- With matrix.perspective() the camera is at the origin looking
+    -- toward +Z, so objects must have a positive Z to be visible.
+    matrix.push()
+        matrix.perspective(60)
+        matrix.translate(0, 0, 3)      -- place cube 3 units in front
+        matrix.rotate(angleX, 1, 0, 0)
+        matrix.rotate(angleY, 0, 1, 0)
+        cubeMesh:draw()
+    matrix.pop()
+end

--- a/docs/source/code/Sphere 3D.codea/Main.lua
+++ b/docs/source/code/Sphere 3D.codea/Main.lua
@@ -1,0 +1,27 @@
+-- 3D Sphere with directional light
+
+function setup()
+    viewer.mode = FULLSCREEN
+    sphereMesh = mesh.sphere(1)
+    sphereMesh.material = material.lit()
+    sphereMesh.material.color = color(100, 180, 255)
+
+    dirLight = light.directional(vec3(1, -1, 1))
+    dirLight.intensity = 2
+
+    angle = 0
+end
+
+function draw()
+    background(20, 20, 30)
+    angle = angle + 0.5
+
+    matrix.push()
+        matrix.perspective(60)
+        light.push(dirLight)
+        matrix.translate(0, 0, 4)
+        matrix.rotate(angle, 0, 1, 0)
+        sphereMesh:draw()
+        light.pop()
+    matrix.pop()
+end

--- a/docs/source/manual/codea_3x.rst
+++ b/docs/source/manual/codea_3x.rst
@@ -55,7 +55,16 @@ This means that there is no longer a ``craft.model`` type, but instead all funct
 
 The practical upshot of this, is that you can use load meshes directly from a file and draw them to the screen using :lua:meth:`mesh.draw`
 
-Part of the new streamlined API design is that almost all features that were restricted to craft scenes can be used directly in the immediate mode drawing API. We now have lighting which can be used with :lua:meth:`mesh.draw` and materials can be used directly with meshes as well
+Part of the new streamlined API design is that almost all features that were restricted to craft scenes can be used directly in the immediate mode drawing API. We now have lighting which can be used with :lua:meth:`mesh.draw` and materials can be used directly with meshes as well.
+
+Lights are pushed/popped onto a rendering stack using :lua:func:`light.push` and :lua:func:`light.pop` as static functions (not methods). Currently only directional lights are supported in immediate mode:
+
+.. code-block:: lua
+
+   dirLight = light.directional(vec3(0, -1, 0))
+   light.push(dirLight)
+   myMesh:draw()
+   light.pop()
 
 Scenes and Entities
 -------------------
@@ -250,3 +259,56 @@ Matrix and Vector Types
 -----------------------
 
 The matrix type has now been split into mat2, mat3, mat4
+
+3D Coordinate System
+--------------------
+
+In Codea 4.x the camera convention changed. When using :lua:func:`matrix.perspective`, the camera sits at the origin and looks toward **positive Z**. This is a left-handed, +Z-forward coordinate system (consistent with Metal and DirectX), which differs from the right-handed, -Z-forward system used in OpenGL and Codea 3.x's Craft.
+
+.. important::
+
+   Objects must be at **positive Z** to be visible. Translate objects forward along +Z, **not** -Z.
+
+.. code-block:: lua
+   :linenos:
+
+   -- Codea 3.x (Craft / OpenGL convention — -Z forward)
+   -- camera(0, 0, 5,  0, 0, 0,  0, 1, 0)  -- camera behind object looking at -Z
+   -- translate(0, 0, -3)                    -- object in front = negative Z
+
+   -- Codea 4.x (Carbide / Metal convention — +Z forward)
+   matrix.push()
+   matrix.perspective(60)
+   matrix.translate(0, 0, 3)   -- object in front = positive Z
+   myMesh:draw()
+   matrix.pop()
+
+Mesh: ``vertices`` vs ``positions``
+------------------------------------
+
+The :lua:attr:`mesh.vertices` and :lua:attr:`mesh.positions` properties serve different purposes:
+
+- **``mesh.vertices``** — sets vertex positions *and* automatically creates a sequential index buffer (0, 1, 2, …). Use this when building a mesh from scratch.
+- **``mesh.positions``** — sets only the vertex positions, **leaving the index buffer untouched**. Use this when modifying an existing mesh (e.g. from a generator or ``mesh.read()``) to deform or animate its vertices without destroying the original index topology.
+
+.. code-block:: lua
+   :linenos:
+
+   -- Building from scratch: use 'vertices' so indices are created automatically
+   m = mesh()
+   m.vertices = { vec3(0,0,0), vec3(1,0,0), vec3(0.5,1,0) }
+   m.colors   = { color(255,0,0), color(0,255,0), color(0,0,255) }
+
+   -- Deforming an existing mesh each frame: use 'positions' to preserve indices
+   sph = mesh.sphere(1)
+   function draw()
+       local pos = sph.positions          -- read current positions
+       for i, p in ipairs(pos) do
+           pos[i] = p * (1 + 0.1 * math.sin(time.elapsed + i))
+       end
+       sph.positions = pos                -- write back, indices unchanged
+       sph:draw()
+   end
+
+This distinction does not apply when reading positions — both properties return the same vertex data.
+

--- a/docs/source/manual/drawing.rst
+++ b/docs/source/manual/drawing.rst
@@ -10,7 +10,7 @@ rendering both 2D and 3D graphics
 The user-defined global :lua:`draw()` function is called once per frame to
 update the contents of the screen
 
-The :lua:`background(r,g,b,a)` function is used to clear the background with a given color. When this isn't called the contents of the background will stay the same as the preivous frame
+The :lua:`background(r,g,b,a)` function is used to clear the background with a given color. When this isn't called the contents of the background will stay the same as the previous frame
 
 Codea uses an hybrid-immediate mode drawing system, where various built-in functions can be used to paint objects to the screen when called, such as :lua:`line()`, :lua:`sprite()` and :lua:`rect()`
 
@@ -39,7 +39,7 @@ Anywhere ``<color>`` is used as a parameter, the following forms can be used:
    style.func(r, g, b, a) -- separate color components in the range 0-255
    style.func(r, g, b) -- only red, green, blue color components with alpha assumed to be 255
    style.func(grey, alpha) -- only greyscale and alpha
-   style.func(grey) -- only grayscale with alph assumed to be 255
+   style.func(grey) -- only grayscale with alpha assumed to be 255
    style.func(color) -- a color object
 
 Matrix
@@ -49,28 +49,261 @@ The matrix module is used to manipulate the current immediate mode transform, vi
 
 By combining different matrix commands, any 2D or 3D drawing setup can be achieved, and there is also the :lua:class:`camera` class which can be used on its own or part of a :lua:class:`scene` for a higher level abstraction
 
-Backround
----------
+The matrix module also uses a fluent syntax, so calls can be chained:
 
+.. code-block:: lua
+
+   -- Translate then rotate in one expression
+   matrix.push().translate(100, 100).rotate(45)
+   rect(0, 0, 50, 50)
+   matrix.pop()
+
+See :doc:`/api/matrix` for a complete reference
+
+3D Drawing
+----------
+
+To draw in 3D, switch from the default 2D orthographic projection to a perspective projection using :lua:func:`matrix.perspective`. Always wrap 3D drawing in a :lua:func:`matrix.push` / :lua:func:`matrix.pop` pair so the 2D projection is restored afterwards.
+
+.. important::
+
+   With :lua:func:`matrix.perspective`, the camera sits at the origin and looks toward **+Z**. Objects must have a **positive Z coordinate** to be visible. Use :lua:func:`matrix.translate` to move objects in front of the camera.
+
+.. code-block:: lua
+
+   function draw()
+       background(20, 20, 30)
+
+       -- All 3D drawing goes inside a matrix.push/pop block
+       matrix.push()
+           matrix.perspective(60)          -- 60° field of view
+           matrix.translate(0, 0, 5)       -- move object 5 units forward (+Z)
+           matrix.rotate(angle, 0, 1, 0)   -- spin around Y axis
+           myMesh:draw()
+       matrix.pop()
+
+       -- 2D drawing after matrix.pop() uses the default screen projection
+       text("Hello", WIDTH/2, 40)
+   end
+
+To position the camera elsewhere in the scene, set a custom view matrix using :lua:func:`matrix.view` together with :lua:func:`mat4.orbit`:
+
+.. code-block:: lua
+
+   matrix.push()
+       matrix.perspective(60)
+       -- Orbit camera: looking at origin from distance 8, tilted 20° up and 45° around Y
+       matrix.view(mat4.orbit(vec3(0, 0, 0), 8, 20, 45))
+       myMesh:draw()
+   matrix.pop()
+
+Background
+----------
+
+:lua:func:`background` clears the screen each frame with a solid color (or image/shader):
+
+.. code-block:: lua
+
+   background(0, 0, 0)        -- black
+   background(40, 40, 50)     -- dark blue-grey
+   background(color.white)    -- using a color object
+
+See :doc:`/api/graphics` for full documentation
 
 Vector Drawing
 --------------
 
+A set of 2D drawing functions are available in the global namespace. They all respect the current :doc:`/api/style` settings:
+
+.. code-block:: lua
+
+   -- Lines
+   style.push().stroke(255, 0, 0).strokeWidth(4)
+   line(100, 100, 400, 300)
+   style.pop()
+
+   -- Shapes
+   style.push().fill(0, 128, 255).stroke(255).strokeWidth(2)
+   rect(WIDTH/2, HEIGHT/2, 200, 100)       -- centered rectangle
+   ellipse(WIDTH/2, HEIGHT/2, 150, 150)    -- circle
+   style.pop()
+
+   -- Polygon
+   style.push().fill(255, 200, 0)
+   polygon(200,100, 300,200, 250,300, 150,300, 100,200)
+   style.pop()
+
+See :doc:`/api/graphics` for a complete list of vector drawing functions
 
 Text
 ----
 
+Use :lua:func:`text` to draw strings to the screen. Text color is set with :lua:func:`style.fill`:
+
+.. code-block:: lua
+
+   style.push().fill(255).fontSize(32).textAlign(CENTER | MIDDLE)
+   text("Hello, Codea!", WIDTH/2, HEIGHT/2)
+   style.pop()
+
+**Emojis require native rendering**
+
+By default Codea uses its own text renderer, which does not support emoji characters (they appear as empty boxes). To render emojis, enable native text rendering with ``TEXT_NATIVE``:
+
+.. code-block:: lua
+
+   -- Emojis render as boxes with the default renderer
+   text("Broken: 🎉 🚀 ❤️", WIDTH/2, HEIGHT/2 + 60)
+
+   -- Enable native rendering to display emojis correctly
+   style.push().textStyle(TEXT_NATIVE)
+   text("Working: 🎉 🚀 ❤️", WIDTH/2, HEIGHT/2)
+   style.pop()
+
+.. note::
+
+   ``TEXT_NATIVE`` uses the system font renderer, so other ``textStyle`` flags (bold, italic, rich text, etc.) are ignored while it is active.
+
 Images and Sprites
 ------------------
+
+Images are loaded with :lua:meth:`image.read` and drawn with :lua:func:`sprite`:
+
+.. code-block:: lua
+
+   function setup()
+       img = image.read(asset.builtin.Blocks.Brick)
+   end
+
+   function draw()
+       background(0)
+       sprite(img, WIDTH/2, HEIGHT/2, 200, 200)
+   end
 
 Context
 -------
 
+The context module lets you draw into an image instead of the screen, using :lua:func:`context.push` and :lua:func:`context.pop`:
+
+.. code-block:: lua
+
+   local target = image(512, 512)
+
+   context.push(target)
+       background(0)
+       style.push().fill(255, 0, 0)
+       ellipse(256, 256, 200, 200)
+       style.pop()
+   context.pop()
+
+   -- Now draw that image to screen
+   sprite(target, WIDTH/2, HEIGHT/2)
+
 Meshes
 ------
+
+The :lua:class:`mesh` class is the primary way to draw custom 3D geometry. You can either use the built-in mesh generators or build geometry manually.
+
+**Built-in mesh generators**
+
+.. code-block:: lua
+
+   sphereMesh   = mesh.sphere(1)          -- sphere, radius 1
+   boxMesh      = mesh.box(vec3(1,1,1))   -- box, 1×1×1
+   cylinderMesh = mesh.cylinder(0.5, 1)   -- radius 0.5, height 1
+   torusMesh    = mesh.torus(0.25, 1)     -- torus
+
+**Drawing a mesh in 3D**
+
+.. code-block:: lua
+
+   function setup()
+       sphereMesh = mesh.sphere(1)
+       angle = 0
+   end
+
+   function draw()
+       background(20, 20, 30)
+       angle = angle + 0.5
+
+       matrix.push()
+           matrix.perspective(60)
+           matrix.translate(0, 0, 4)
+           matrix.rotate(angle, 0, 1, 0)
+           sphereMesh:draw()
+       matrix.pop()
+   end
+
+**Building a mesh manually — use** ``vertices`` **not** ``positions``
+
+When setting mesh geometry by hand, use the :lua:attr:`mesh.vertices` property. It sets positions **and** automatically creates a sequential index buffer so the mesh draws immediately. :lua:attr:`mesh.positions` only updates positions without touching the index buffer — useful for deforming an existing mesh, but on a fresh empty mesh it will leave the indices empty and nothing will be drawn:
+
+.. code-block:: lua
+
+   -- CORRECT: vertices sets positions AND indices automatically
+   m = mesh()
+   m.vertices = { vec3(0,0,0), vec3(1,0,0), vec3(0.5,1,0) }  -- one triangle
+   m.colors   = { color(255,0,0), color(0,255,0), color(0,0,255) }
+   m:draw()
+
+   -- Use positions only to deform an existing mesh (preserves its index buffer)
+   sph = mesh.sphere(1)
+   -- modify sph.positions each frame to animate without breaking sphere indices
+
+**Complete example: Rotating RGB Cube**
+
+.. collapse:: Example
+
+   .. literalinclude:: /code/RGB Cube.codea/Main.lua
+      :language: lua
 
 Shaders and Materials
 ---------------------
 
+Both shaders and materials can be applied to a mesh to control how it is rendered. See :doc:`/api/shader`, :doc:`/api/material` and :doc:`shaders` for details.
+
 Lighting
 --------
+
+Codea supports dynamic lighting via :doc:`/api/light`. Generated meshes (``mesh.sphere()``, ``mesh.box()``, etc.) render black by default because there are no lights and the default material requires lighting. There are two ways to make them visible:
+
+**Option 1: Unlit material with a color** (no light needed):
+
+.. code-block:: lua
+
+   sph = mesh.sphere(1)
+   sph.material = material.unlit()
+   sph.material.color = color(100, 180, 255)
+
+**Option 2: Lit material with a directional light** (produces 3D shading):
+
+.. code-block:: lua
+
+   function setup()
+       sph = mesh.sphere(1)
+       sph.material = material.lit()
+       sph.material.color = color(100, 180, 255)
+
+       dirLight = light.directional(vec3(1, -1, 1))
+       dirLight.intensity = 2
+   end
+
+   function draw()
+       background(20, 20, 30)
+       matrix.push()
+           matrix.perspective(60)
+           light.push(dirLight)
+           matrix.translate(0, 0, 4)
+           sph:draw()
+           light.pop()
+       matrix.pop()
+   end
+
+.. note::
+
+   Only ``light.directional()`` is currently supported for immediate-mode rendering. ``light.point()`` and ``light.spot()`` are defined but not yet implemented by the renderer.
+
+.. collapse:: Full sphere example
+
+   .. literalinclude:: /code/Sphere 3D.codea/Main.lua
+      :language: lua

--- a/docs/source/manual/drawing.rst
+++ b/docs/source/manual/drawing.rst
@@ -265,7 +265,7 @@ Both shaders and materials can be applied to a mesh to control how it is rendere
 Lighting
 --------
 
-Codea supports dynamic lighting via :doc:`/api/light`. Generated meshes (``mesh.sphere()``, ``mesh.box()``, etc.) render black by default because there are no lights and the default material requires lighting. There are two ways to make them visible:
+Codea supports dynamic lighting via :doc:`/api/light`. Generated meshes (``mesh.sphere()``, ``mesh.box()``, etc.) use a lit material by default, so without any lights they render black. There are two ways to make them visible:
 
 **Option 1: Unlit material with a color** (no light needed):
 


### PR DESCRIPTION
- Complete the drawing.rst manual page with Style, Matrix, 3D Drawing, Background, Vector Drawing, Text (with emoji/TEXT_NATIVE note), Images/Sprites, Context, Meshes, Shaders, and Lighting sections
- Add mesh.vertices vs mesh.positions clarification (with index buffer warning) to mesh.rst and the mesh deformation pattern to codea_3x.rst
- Add +Z-forward coordinate system note to matrix.rst and codea_3x.rst
- Document lighting: mesh.sphere() renders black without material/light; only light.directional() works in immediate mode
- Add working code examples: RGB Cube (rotating, vertex-colored) and Sphere 3D (directional light + material.lit())
- All examples tested and verified working in iOS Simulator