### PR TITLE
Migrate examples to image.filter / image.wrap API

### DIFF
--- a/docs/source/code/Examples/How to Codea/0. Migration Guide/3. Drawing.codea/Main.lua
+++ b/docs/source/code/Examples/How to Codea/0. Migration Guide/3. Drawing.codea/Main.lua
@@ -18,8 +18,7 @@ function setup()
     -- Load an image atlas    
     local adventure = asset.builtin.Pixel_Adventure
     slime = image.read(adventure.Enemies.Slime.."/Idle-Run (44x30).png")
-    slime.sampler.u = image.clamp
-    slime.sampler.v = image.clamp
+    slime.wrap = image.wrap.clamp
     
     -- Slice up the atlas using the sprite cell size
     -- Individual slices can be accessed with atlas[i]

--- a/docs/source/code/Examples/How to Codea/5. Shaders/?? - Procedural Flames/Main.lua
+++ b/docs/source/code/Examples/How to Codea/5. Shaders/?? - Procedural Flames/Main.lua
@@ -232,8 +232,8 @@ function setup()
     
     trails = shader.read(asset.Trails)
     trailEffect = shader.read(asset.Trail_Effect_Baked)
-    trailEffect._gradient1.sampler.u = image.clamp
-    trailEffect._gradient.sampler.u = image.clamp
+    trailEffect._gradient1.sampler.u = image.wrap.clamp
+    trailEffect._gradient.sampler.u = image.wrap.clamp
     --trailEffect._gradient = trailEffect._gradient
     
     


### PR DESCRIPTION
## Summary

The top-level constants `image.point`, `image.linear`, `image.repeat`, `image.clamp`, `image.mirror`, and the per-instance `image.smooth` bool are being removed in the Codea engine in favor of namespaced sub-tables (`image.filter.*` / `image.wrap.*`) plus a graphics-style scope (`style.filter` / `style.wrap`). See [twolivesleft/codea PR #381](https://bitbucket.org/TwoLivesLeft/codea/pull-requests/381).

This PR updates the two example projects under "How to Codea" that referenced the removed constants:

- `docs/source/code/Examples/How to Codea/0. Migration Guide/3. Drawing.codea/Main.lua` — also adopts the new image-level setter shorthand (`myImg.wrap = image.wrap.clamp` instead of two separate `sampler.u` / `sampler.v` assignments).
- `docs/source/code/Examples/How to Codea/5. Shaders/?? - Procedural Flames/Main.lua`.

## Test plan

- [ ] Open the Migration Guide / Drawing example in Codea4 (after the engine PR merges) and verify the slime atlas renders without wrapping artifacts.
- [ ] Open the Procedural Flames example and verify the trail effect samples cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)